### PR TITLE
Update to ARGs and VOD Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ wubby-snatch month -c <number_of_vods>
 
 Month: Specify the month in `MMM_YYYY` format (e.g., `mar_2025`) from which you want to download VODs.
 
--c <number_of_vods>: Specify how many VODs you want to download. For example, `-c 5` to download the 5 most recent VODs.
+-c <number_of_vods> (optional): Specify how many VODs you want to download. For example, `-c 5` to download the 5 most recent VODs. Default is 1.
 
 -dlf <path to folder> (optional): Specify the full file path of where to download VODs. If not specified, will revert to default.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install wubby-vod-downloader==1.1.0
 
 ## Usage
 
-Navigate to the directory where you want to store your VODs. The script will create a new folder named `vod_downloads` where the files will be saved.
+Navigate to the directory where you want to store your VODs. By default, the script will create a new folder named `vod_downloads` where the files will be saved.
 
 Run the command to download your desired VODs:
 
@@ -26,13 +26,23 @@ Month: Specify the month in `MMM_YYYY` format (e.g., `mar_2025`) from which you 
 
 -c <number_of_vods>: Specify how many VODs you want to download. For example, `-c 5` to download the 5 most recent VODs.
 
-## Example
+-dlf <path to folder> (optional): Specify the full file path of where to download VODs. If not specified, will revert to default.
+
+-k (optional): Kick Streams Only
+
+-t (optional): Twitch Streams Only
+
+## Examples
 
 ```bash
 wubby-snatch mar_2025 -c 5
 ```
-
 This will download the 5 most recent VODs from March 2025.
+
+```bash
+ wubby-snatch apr_2025 -c 6 -dlf "V:\Stream VODs" -k
+```
+This will download the 6 most recent Kick VODs from April, 2025 to "V:\Stream VODs".
 
 ## Skipping Already Downloaded VODs
 

--- a/vod_downloader/vod_downloader.py
+++ b/vod_downloader/vod_downloader.py
@@ -81,14 +81,16 @@ def download_vods(month_folder, count=5, kickonly=False, dlfolder='vod_downloads
     # Initialize a progress bar with `tqdm`
     for i, (vod_link, _) in enumerate(tqdm(sorted_vods[:count], desc="Downloading VODs", unit="VOD", dynamic_ncols=True)):
         vod_url = base_url + month_folder + "/" + vod_link
-        vod_filename = os.path.join(download_folder, vod_link.split('/')[-1])
+        ymd=sorted_vods[:count][0][1].strftime('%Y-%m-')
+        vod_filename = os.path.join(download_folder,ymd+vod_link.split('/')[-1])
 
         # Check if the VOD has already been downloaded
         if os.path.exists(vod_filename):
             print(f"Skipping {vod_filename}, already downloaded.")
             continue  # Skip this VOD if it already exists
 
-        print(f"Downloading VOD {i+1}: {vod_url}")
+        print(f"Downloading VOD {i+1}: {vod_url} to {vod_filename}")
+        # return
         response = requests.get(vod_url, stream=True)
         
         # Save the VOD to a file with progress

--- a/vod_downloader/vod_downloader.py
+++ b/vod_downloader/vod_downloader.py
@@ -31,7 +31,7 @@ def get_sorted_months():
     return sorted_months
 
 # Function to get and sort VODs by timestamp within a month folder
-def get_sorted_vods(month_folder):
+def get_sorted_vods(month_folder,kickonly,twitchonly):
     month_url = base_url + month_folder + "/"
     response = requests.get(month_url)
     soup = BeautifulSoup(response.text, 'html.parser')
@@ -46,7 +46,14 @@ def get_sorted_vods(month_folder):
             if timestamp:
                 try:
                     timestamp = datetime.strptime(timestamp, "%Y-%b-%d %H:%M")
-                    vod_links.append((link['href'], timestamp))
+                    if (kickonly):
+                        if 'kickapilol' in link['href']:
+                            vod_links.append((link['href'], timestamp))
+                    elif (twitchonly):
+                        if 'kickapilol' not in link['href']:
+                            vod_links.append((link['href'], timestamp))
+                    else:
+                        vod_links.append((link['href'], timestamp))
                 except ValueError:
                     continue  # Skip any entries that don't have a valid timestamp
 
@@ -55,15 +62,19 @@ def get_sorted_vods(month_folder):
     return sorted_vods
 
 # Function to download VODs from the most recent month
-def download_vods(month_folder, count=5):
-    sorted_vods = get_sorted_vods(month_folder)
+def download_vods(month_folder, count=5, kickonly=False, dlfolder='vod_downloads',twitchonly=False):
+    sorted_vods = get_sorted_vods(month_folder,kickonly,twitchonly)
+
+    # comment these in to test fetch without actual download
+    # print(sorted_vods)
+    # return
 
     if not sorted_vods:
         print(f"No VODs found in the month folder: {month_folder}")
         return
 
     # Create a folder for the downloads if it doesn't exist
-    download_folder = 'vod_downloads'
+    download_folder = dlfolder
     if not os.path.exists(download_folder):
         os.makedirs(download_folder)
 
@@ -95,10 +106,12 @@ def main():
     parser = argparse.ArgumentParser(description="Download VODs from the Wubby TV archive.")
     parser.add_argument('month_folder', help='The folder name of the month to download VODs from')
     parser.add_argument('-c', '--count', type=int, default=5, help='Number of VODs to download (default: 5)')
-    
+    parser.add_argument('-dlf', help='The folder name to download to.')
+    parser.add_argument('-k', '--kick', action='store_true', help='Kick Vods Only')
+    parser.add_argument('-t', '--twitch', action='store_true', help='Twitch Vods Only')
     args = parser.parse_args()
     
-    download_vods(args.month_folder, count=args.count)
+    download_vods(args.month_folder, count=args.count, dlfolder=args.dlf, kickonly=args.kick, twitchonly=args.twitch)
 
 if __name__ == "__main__":
     main()

--- a/vod_downloader/vod_downloader.py
+++ b/vod_downloader/vod_downloader.py
@@ -73,6 +73,7 @@ def download_vods(month_folder, count=5, kickonly=False, dlfolder='vod_downloads
         print(f"No VODs found in the month folder: {month_folder}")
         return
 
+    print(dlfolder)
     # Create a folder for the downloads if it doesn't exist
     download_folder = dlfolder
     if not os.path.exists(download_folder):
@@ -107,8 +108,8 @@ def download_vods(month_folder, count=5, kickonly=False, dlfolder='vod_downloads
 def main():
     parser = argparse.ArgumentParser(description="Download VODs from the Wubby TV archive.")
     parser.add_argument('month_folder', help='The folder name of the month to download VODs from')
-    parser.add_argument('-c', '--count', type=int, default=5, help='Number of VODs to download (default: 5)')
-    parser.add_argument('-dlf', help='The folder name to download to.')
+    parser.add_argument('-c', '--count', nargs='?', default=1, type=int, help='Number of VODs to download (default: 5)')
+    parser.add_argument('-dlf', nargs='?', default='vod_downloads', help='The folder name to download to.')
     parser.add_argument('-k', '--kick', action='store_true', help='Kick Vods Only')
     parser.add_argument('-t', '--twitch', action='store_true', help='Twitch Vods Only')
     args = parser.parse_args()


### PR DESCRIPTION
Argument Updates:

-c: optional, default to 1 for grabbing most recent VOD when called standalone.
-dlf: - new, specifies download folder. If not passed, defaults back to "vod_downloads" folder.
-k: optional flag for KICK ONLY that will grab all VODs with "kickapilol" in the title.
-t: optional flag for TWITCH ONLY that will omit all VODs with "kickapilol" in the title.

I also modified the naming convention of the downloaded VODs to append YYYY-MM- to the beginning, for organizational purposes.

For example, when pointed to April 2025, it will now add '2025-04-' to the beginning of the VOD title, so that differentiation can be made between VODs from separate months.
